### PR TITLE
Feat: Clipboard and Builder's hut integration

### DIFF
--- a/.changeset/nine-aliens-stop.md
+++ b/.changeset/nine-aliens-stop.md
@@ -1,0 +1,5 @@
+---
+"CreateColonies": minor
+---
+
+feat: add integration to note requirements from Minecolonies' builder's hut onto Create's clipboard

--- a/build.gradle
+++ b/build.gradle
@@ -174,11 +174,18 @@ dependencies {
     implementation (fg.deobf("com.ldtteam:structurize:${structurize_version}")){
         transitive = false
     }
+    /*
+    // When testing without minecolonies installed
+    compileOnly (fg.deobf("com.ldtteam:minecolonies:${minecolonies_version}")){
+        transitive = false
+    }
+    */
+    // When testing with minecolonies installed
     implementation (fg.deobf("com.ldtteam:minecolonies:${minecolonies_version}")){
         transitive = false
     }
     runtimeOnly (fg.deobf("com.ldtteam:blockui:${blockui_version}"))
-    runtimeOnly (fg.deobf("com.ldtteam:domum_ornamentum:${domum_ornamentum_version}"))
+    implementation (fg.deobf("com.ldtteam:domum_ornamentum:${domum_ornamentum_version}"))
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,9 +45,9 @@ flywheel_version = 1.0.2
 registrate_version = MC1.20-1.3.3
 
 blockui_version=1.20.1-1.0.190-snapshot
-domum_ornamentum_version=1.20.1-1.0.184-BETA
-structurize_version=1.20.1-1.0.771-snapshot
-minecolonies_version=1.20.1-1.1.903-snapshot
+domum_ornamentum_version=1.20.1-1.0.288-snapshot
+structurize_version=1.20.1-1.0.781-snapshot
+minecolonies_version=1.20.1-1.1.1011-snapshot
 
 ## Mod Properties
 

--- a/src/main/java/nl/motionlesstrain/createcolonies/CreateColonies.java
+++ b/src/main/java/nl/motionlesstrain/createcolonies/CreateColonies.java
@@ -27,6 +27,8 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
+import nl.motionlesstrain.createcolonies.compatibility.Minecolonies;
+import nl.motionlesstrain.createcolonies.hooks.HooksInitialiser;
 import nl.motionlesstrain.createcolonies.placementhandlers.PlacementHandlers;
 import org.slf4j.Logger;
 
@@ -84,6 +86,11 @@ public class CreateColonies {
 
         // Register our mod's ForgeConfigSpec so that Forge can create and load the config file for us
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.SPEC);
+
+        // Register the event listeners, e.g. for items outside our control
+        HooksInitialiser.registerHooks();
+        // And initialise the compatibility code, for non-required dependencies
+        Minecolonies.initialiseCompat();
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {

--- a/src/main/java/nl/motionlesstrain/createcolonies/compatibility/CompatRunner.java
+++ b/src/main/java/nl/motionlesstrain/createcolonies/compatibility/CompatRunner.java
@@ -1,0 +1,8 @@
+package nl.motionlesstrain.createcolonies.compatibility;
+
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface CompatRunner {
+  void run(Supplier<Runnable> function);
+}

--- a/src/main/java/nl/motionlesstrain/createcolonies/compatibility/Minecolonies.java
+++ b/src/main/java/nl/motionlesstrain/createcolonies/compatibility/Minecolonies.java
@@ -1,0 +1,35 @@
+package nl.motionlesstrain.createcolonies.compatibility;
+
+import net.minecraftforge.fml.ModList;
+
+import java.util.function.Supplier;
+
+public class Minecolonies {
+  private static class MinecoloniesNotInstalled implements CompatRunner {
+    @Override
+    public void run(Supplier<Runnable> ignored) {
+      // Do nothing, as Minecolonies is not installed
+    }
+  }
+
+  private static class MinecoloniesInstalled implements CompatRunner {
+    @Override
+    public void run(Supplier<Runnable> suppl) {
+      final Runnable function = suppl.get();
+      function.run();
+    }
+  }
+
+  private static CompatRunner minecoloniesRunner;
+  public static void initialiseCompat() {
+    if (ModList.get().isLoaded("minecolonies")) {
+      minecoloniesRunner = new MinecoloniesInstalled();
+    } else {
+      minecoloniesRunner = new MinecoloniesNotInstalled();
+    }
+  }
+
+  public static void runIfInstalled(Supplier<Runnable> code) {
+    minecoloniesRunner.run(code);
+  }
+}

--- a/src/main/java/nl/motionlesstrain/createcolonies/hooks/HooksInitialiser.java
+++ b/src/main/java/nl/motionlesstrain/createcolonies/hooks/HooksInitialiser.java
@@ -1,0 +1,9 @@
+package nl.motionlesstrain.createcolonies.hooks;
+
+import net.minecraftforge.common.MinecraftForge;
+
+public class HooksInitialiser {
+  public static void registerHooks() {
+    MinecraftForge.EVENT_BUS.register(InteractionHook.class);
+  }
+}

--- a/src/main/java/nl/motionlesstrain/createcolonies/hooks/InteractionHook.java
+++ b/src/main/java/nl/motionlesstrain/createcolonies/hooks/InteractionHook.java
@@ -1,0 +1,73 @@
+package nl.motionlesstrain.createcolonies.hooks;
+
+import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
+import com.mojang.logging.LogUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import nl.motionlesstrain.createcolonies.compatibility.Minecolonies;
+import org.slf4j.Logger;
+
+import java.util.TreeMap;
+
+import static com.minecolonies.core.colony.buildings.modules.BuildingModules.BUILDING_RESOURCES;
+import static nl.motionlesstrain.createcolonies.resources.MinecoloniesResources.Blocks.blockHutBuilder;
+
+public class InteractionHook {
+  private static final Logger LOGGER = LogUtils.getLogger();
+
+  @SubscribeEvent
+  public static void onPlayerRightClick(PlayerInteractEvent.RightClickBlock evt) {
+    final Player player = evt.getEntity();
+    if (!player.isShiftKeyDown()) return;
+
+    final Level world = evt.getLevel();
+    final BlockPos blockPosClicked = evt.getHitVec().getBlockPos();
+    final BlockState blockStateClicked = world.getBlockState(blockPosClicked);
+
+    if (blockHutBuilder != null && blockStateClicked.is(blockHutBuilder)) {
+      evt.setCanceled(true);
+      evt.setResult(Event.Result.DENY);
+      if (evt.getSide().isClient()) return;
+
+      if (player instanceof FakePlayer) return;
+
+      Minecolonies.runIfInstalled(() -> () -> {
+        final BlockEntity blockEntity = world.getBlockEntity(blockPosClicked);
+        if (blockEntity instanceof AbstractTileEntityColonyBuilding buildingEntity) {
+          final IBuilding building = buildingEntity.getBuilding();
+          final var resourcesModule = building.getModule(BUILDING_RESOURCES);
+          if (resourcesModule != null) {
+            final var allResources = resourcesModule.getNeededResources();
+            final TreeMap<String, NeededItem> neededResources = new TreeMap<>();
+            allResources.values().forEach(resource -> {
+              final int entireAmount = resource.getAmount(),
+                  availableAmount = resource.getAvailable(),
+                  deliveringAmount = resource.getAmountInDelivery(),
+                  neededAmount = entireAmount - availableAmount - deliveringAmount;
+              final ItemStack itemStack = resource.getItemStack();
+              if (neededAmount > 0) {
+                neededResources.put(itemStack.getItem().getName(itemStack).getString(),
+                    new NeededItem(itemStack, neededAmount, entireAmount));
+              }
+            });
+            neededResources.forEach((name, neededItem) -> {
+              System.out.println(name + ": " + neededItem.count() + "(" + neededItem.totalCount() + ")");
+            });
+            // TODO: fill clipboard with this information
+          }
+        }
+      });
+    }
+  }
+
+  private record NeededItem(ItemStack item, int count, int totalCount) {}
+}

--- a/src/main/java/nl/motionlesstrain/createcolonies/resources/CreateResources.java
+++ b/src/main/java/nl/motionlesstrain/createcolonies/resources/CreateResources.java
@@ -71,5 +71,8 @@ public class CreateResources {
 
         @ObjectHolder(registryName = "minecraft:item", value = "create:deployer")
         public static Item deployer;
+
+        @ObjectHolder(registryName = "minecraft:item", value = "create:clipboard")
+        public static Item clipboard;
     }
 }

--- a/src/main/java/nl/motionlesstrain/createcolonies/resources/MinecoloniesResources.java
+++ b/src/main/java/nl/motionlesstrain/createcolonies/resources/MinecoloniesResources.java
@@ -1,0 +1,11 @@
+package nl.motionlesstrain.createcolonies.resources;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.ObjectHolder;
+
+public class MinecoloniesResources {
+  public static class Blocks {
+    @ObjectHolder(registryName = "minecraft:block", value = "minecolonies:blockhutbuilder")
+    public static Block blockHutBuilder = null;
+  }
+}

--- a/src/main/resources/assets/createcolonies/lang/en_us.json
+++ b/src/main/resources/assets/createcolonies/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "nl.motionlesstrain.createcolonies.clipboard.registered": "The required resources of %s are noted down on the clipboard"
+}


### PR DESCRIPTION
## Proposed changes
Whenever someone holds a clipboard from Create, and sneak+interacts with the builder's hut (or actually anything that contains a resource list, so the mine too),
the clipboard gets a list of all the items that are still needed at this point

Note: Similar to the resource scroll being able to note a snapshot of the contents of a warehouse, this is a snapshot.
It takes immediate deliveries into account, but no other open requests of the builder, or items in your own inventory.
So when you make the list, and two minutes later, you bring all the cobblestone needed, you could still see the cobblestone on the (Create) clipboard. You need to sneak+interact again to update the list
